### PR TITLE
Applying patch available under PIG-4629 to resolve compilation issue.

### DIFF
--- a/src/org/apache/pig/builtin/HiveUDFBase.java
+++ b/src/org/apache/pig/builtin/HiveUDFBase.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hive.ql.udf.generic.Collector;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFResolver;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
@@ -103,8 +104,12 @@ abstract class HiveUDFBase extends EvalFunc<Object> {
         String className = funcName;
         Class udfClass;
         if (FunctionRegistry.getFunctionNames().contains(funcName)) {
-            FunctionInfo func = FunctionRegistry.getFunctionInfo(funcName);
-            udfClass = func.getFunctionClass();
+	    try {
+		FunctionInfo func = FunctionRegistry.getFunctionInfo(funcName);
+		udfClass = func.getFunctionClass();
+	    } catch (SemanticException s)  {
+		throw new IOException("Hive UDF raised SemanticException" + funcName);
+	    }
         } else {
             udfClass = PigContext.resolveClassName(className);
             if (udfClass == null) {


### PR DESCRIPTION
The compilation issue was due to the exception SemanticException thrown by org.apache.hadoop.hive.ql.exec.FunctionRegistry#getFunctionInfo() if Hive version is 1.1.0 or above.
