### PR TITLE
Added hbase-procedure and netty-all dependencies to resolve PIG UT failures

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -279,6 +279,13 @@
       <exclude org="asm" module="asm"/>
     </dependency>
 
+    <!-- To resolve java.lang.NoClassDefFoundError: org/apache/hadoop/hbase/procedure2/Procedure when running TestHBaseStorage.
+         Procedure V2 is new and initially dropped into hbase 1.1 -->
+    <dependency org="org.apache.hbase" name="hbase-procedure" rev="${hbase95.version}" conf="hbase95->master">
+      <artifact name="hbase-procedure" type="jar"/>
+      <!--<artifact name="hbase-procedure" type="test-jar" ext="jar" m:classifier="tests"/>-->
+    </dependency>
+
     <!-- HBase dependency in format for releases higher or equal to 0.95 -->
     <dependency org="org.apache.hbase" name="hbase-client" rev="${hbase95.version}" conf="hbase95->master">
       <artifact name="hbase-client" type="jar"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -250,6 +250,7 @@
     <dependency org="org.antlr" name="ST4" rev="${stringtemplate.version}" conf="compile->default"/>
     <dependency org="org.apache.zookeeper" name="zookeeper" rev="${zookeeper.version}" conf="compile->master"/>
     <dependency org="io.netty" name="netty" rev="${netty.version}" conf="test->master"/>
+    <dependency org="io.netty" name="netty-all" rev="${netty-all.version}" conf="test->master"/>
     <dependency org="dk.brics.automaton" name="automaton" rev="1.11-8" conf="compile->default"/>
 
     <dependency org="org.jruby" name="jruby-complete" rev="${jruby.version}" conf="compile->master"/>

--- a/ivy/libraries.properties
+++ b/ivy/libraries.properties
@@ -72,6 +72,7 @@ antlr.version=3.4
 stringtemplate.version=4.0.4
 log4j.version=1.2.16
 netty.version=3.6.6.Final
+netty-all.version=4.0.23.Final
 rats-lib.version=0.5.1
 slf4j-api.version=1.6.1
 slf4j-log4j12.version=1.6.1


### PR DESCRIPTION
1.  The dependency netty-all is added to resolve java.lang.NoClassDefFoundError: io/netty/channel/EventLoopGroup.
   A JIRA was already open for this issue - https://issues.apache.org/jira/browse/PIG-4630
2. The dependency hbase-procedure is added to resolve java.lang.NoClassDefFoundError: org/apache/hadoop/hbase/procedure2/Procedure
   A JIRA was already open for this issue - https://issues.apache.org/jira/browse/PIG-4631
